### PR TITLE
Dynamic Author items/page feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,8 +13,8 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/explore" element={<Explore />} />
-        <Route path="/author" element={<Author />} />
-        <Route path="/item-details" element={<ItemDetails />} />
+        <Route path="/author/:id" element={<Author />} />
+        <Route path="/item-details/:nftId" element={<ItemDetails />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/components/author/AuthorItems.jsx
+++ b/src/components/author/AuthorItems.jsx
@@ -1,63 +1,218 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import axios from "axios";
+
+import AuthorImageFallback from "../../images/author_thumbnail.jpg";
+import NftImageFallback from "../../images/nftImage.jpg";
+
+const API = "https://us-central1-nft-cloud-functions.cloudfunctions.net/authors";
+
+// find the items array regardless of how the CF wraps it
+function getItems(data) {
+  if (Array.isArray(data)) return data;
+  if (data && typeof data === "object") {
+    const keys = ["nftItems", "nftCollection", "items", "nfts", "created"];
+    for (const k of keys) if (Array.isArray(data[k])) return data[k];
+    // last resort: first array property we can find
+    for (const k of Object.keys(data)) {
+      if (Array.isArray(data[k])) return data[k];
+    }
+  }
+  return [];
+}
+
+// normalize one card’s props
+function normalizeItem(raw, idx, authorMeta) {
+  const cover =
+    raw?.nftImage || raw?.image || raw?.cover || raw?.banner || NftImageFallback;
+  const title = raw?.title || raw?.name || "Untitled";
+  const price =
+    typeof raw?.price === "number" ? raw.price : Number(raw?.price) || 0;
+  const likes =
+    typeof raw?.likes === "number" ? raw.likes : Number(raw?.likes) || 0;
+  const nftId = raw?.nftId ?? raw?.id ?? idx;
+
+  return {
+    cover,
+    title,
+    price,
+    likes,
+    nftId,
+    author: {
+      id: raw?.authorId ?? raw?.author?.id ?? authorMeta.id ?? null,
+      avatar:
+        raw?.authorImage ||
+        raw?.author?.avatar ||
+        authorMeta.avatar ||
+        AuthorImageFallback,
+    },
+  };
+}
 
 const AuthorItems = () => {
+  const { id } = useParams(); // /author/:id
+  const [items, setItems] = useState([]);
+  const [authorMeta, setAuthorMeta] = useState({
+    id: null,
+    avatar: AuthorImageFallback,
+  });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) return;
+    let alive = true;
+    setLoading(true);
+
+    axios
+      .get(API, {
+        timeout: 8000,
+        params: { author: id }, // <- no quotes; API expects raw id
+      })
+      .then(({ data }) => {
+        if (!alive) return;
+
+        const rawItems = getItems(data);
+
+        // lift page-level author meta if present, else infer from the first item
+        const meta = { id, avatar: AuthorImageFallback };
+        if (data && typeof data === "object") {
+          meta.id = data.authorId ?? data.id ?? id;
+          meta.avatar = data.authorImage || data.avatar || meta.avatar;
+        }
+        if (rawItems.length) {
+          const f = rawItems[0] || {};
+          meta.id = f.authorId ?? f.author?.id ?? meta.id;
+          meta.avatar = f.authorImage || f.author?.avatar || meta.avatar;
+        }
+        setAuthorMeta(meta);
+
+        setItems(rawItems.map((r, i) => normalizeItem(r, i, meta)));
+      })
+      .catch((err) => {
+        console.warn("Author items fetch failed:", err?.message || err);
+        setItems([]);
+      })
+      .finally(() => alive && setLoading(false));
+
+    return () => {
+      alive = false;
+    };
+  }, [id]);
+
   return (
-    <div className="de_tab_content">
-      <div className="tab-1">
-        <div className="row">
-          {new Array(8).fill(0).map((_, index) => (
-            <div className="col-lg-3 col-md-6 col-sm-6 col-xs-12" key={index}>
+    <div className="row">
+      {loading
+        ? Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={`sk-${i}`}
+              className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+              style={{ display: "block", backgroundSize: "cover" }}
+            >
               <div className="nft__item">
                 <div className="author_list_pp">
-                  <Link to="">
-                    <img className="lazy" src={AuthorImage} alt="" />
+                  <div
+                    className="skeleton-box"
+                    style={{ width: 42, height: 42, borderRadius: "50%" }}
+                  />
+                </div>
+                <div
+                  className="skeleton-box"
+                  style={{
+                    height: 220,
+                    borderRadius: 12,
+                    marginTop: 8,
+                    marginBottom: 12,
+                  }}
+                />
+                <div className="nft__item_info">
+                  <div
+                    className="skeleton-box"
+                    style={{
+                      height: 18,
+                      width: "60%",
+                      borderRadius: 6,
+                      marginBottom: 10,
+                    }}
+                  />
+                  <div
+                    className="skeleton-box"
+                    style={{ height: 14, width: 80, borderRadius: 6 }}
+                  />
+                </div>
+              </div>
+            </div>
+          ))
+        : items.map(({ cover, title, price, likes, nftId, author }, index) => (
+            <div
+              key={nftId ?? index}
+              className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+              style={{ display: "block", backgroundSize: "cover" }}
+            >
+              <div className="nft__item">
+                {/* Author avatar (clickable back to author page) */}
+                <div className="author_list_pp">
+                  <Link
+                    to={
+                      (author?.id ?? authorMeta.id) != null
+                        ? `/author/${author?.id ?? authorMeta.id}`
+                        : "/author"
+                    }
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="top"
+                    title="Creator"
+                  >
+                    <img
+                      className="lazy"
+                      src={author?.avatar || authorMeta.avatar}
+                      alt="author avatar"
+                    />
                     <i className="fa fa-check"></i>
                   </Link>
                 </div>
+
+                {/* NFT media */}
                 <div className="nft__item_wrap">
                   <div className="nft__item_extra">
                     <div className="nft__item_buttons">
                       <button>Buy Now</button>
                       <div className="nft__item_share">
                         <h4>Share</h4>
-                        <a href="" target="_blank" rel="noreferrer">
+                        <a href="#" target="_blank" rel="noreferrer">
                           <i className="fa fa-facebook fa-lg"></i>
                         </a>
-                        <a href="" target="_blank" rel="noreferrer">
+                        <a href="#" target="_blank" rel="noreferrer">
                           <i className="fa fa-twitter fa-lg"></i>
                         </a>
-                        <a href="">
+                        <a href="#">
                           <i className="fa fa-envelope fa-lg"></i>
                         </a>
                       </div>
                     </div>
                   </div>
-                  <Link to="/item-details">
-                    <img
-                      src={nftImage}
-                      className="lazy nft__item_preview"
-                      alt=""
-                    />
+
+                  <Link to={nftId != null ? `/item-details/${nftId}` : "/item-details"}>
+                    <img className="lazy nft__item_preview" src={cover} alt={title} />
                   </Link>
                 </div>
+
+                {/* Meta */}
                 <div className="nft__item_info">
-                  <Link to="/item-details">
-                    <h4>Pinky Ocean</h4>
+                  <Link to={nftId != null ? `/item-details/${nftId}` : "/item-details"}>
+                    <h4>{title}</h4>
                   </Link>
-                  <div className="nft__item_price">2.52 ETH</div>
+                  <div className="nft__item_price">{price} ETH</div>
                   <div className="nft__item_like">
                     <i className="fa fa-heart"></i>
-                    <span>97</span>
+                    <span>{likes}</span>
                   </div>
                 </div>
               </div>
             </div>
           ))}
-        </div>
-      </div>
+
+      {!loading && items.length === 0 && (
+        <div className="col-12 text-center text-muted py-4">No items found.</div>
+      )}
     </div>
   );
 };

--- a/src/pages/Author.jsx
+++ b/src/pages/Author.jsx
@@ -1,8 +1,12 @@
 // src/pages/Author.jsx
 // Notes (from me to future me):
 // - Kept original structure/classes so we don’t fight site-wide CSS.
-// - Only change is: read :id from the route, fetch author by that id, and hydrate the header.
-// - Safe fallbacks are in place so the UI doesn’t break if a field is missing.
+// - Read :id from the route, fetch author, hydrate the header.
+// - Added a front-end only Follow/Unfollow toggle:
+//   * Button label switches between "Follow" and "Unfollow"
+//   * Follower count increments/decrements locally (no backend)
+//   * Resets when the route :id changes
+// - Safe fallbacks in place so the UI doesn’t break if a field is missing.
 
 import React, { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
@@ -15,7 +19,7 @@ import AuthorImageFallback from "../images/author_thumbnail.jpg";
 const API =
   "https://us-central1-nft-cloud-functions.cloudfunctions.net/authors";
 
-// normalize anything the function might return into what we render
+// Normalize anything the function might return into what we render
 function normalizeAuthor(raw) {
   return {
     name: raw?.name || raw?.authorName || "Unknown Artist",
@@ -31,16 +35,23 @@ function normalizeAuthor(raw) {
 
 const Author = () => {
   const { id } = useParams(); // /author/:id
+
   const [author, setAuthor] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // fetch the author when :id changes
+  // --- Follow UI state (front-end only) ---
+  const [isFollowing, setIsFollowing] = useState(false);
+  const [followerCount, setFollowerCount] = useState(0);
+
+  // Fetch the author when :id changes
   useEffect(() => {
     let alive = true;
     setLoading(true);
 
     if (!id) {
       setAuthor(null);
+      setFollowerCount(0);
+      setIsFollowing(false);
       setLoading(false);
       return;
     }
@@ -51,11 +62,18 @@ const Author = () => {
         if (!alive) return;
         // API may return an object or array — be defensive
         const raw = Array.isArray(data) ? data[0] : data;
-        setAuthor(raw ? normalizeAuthor(raw) : null);
+        const norm = raw ? normalizeAuthor(raw) : null;
+        setAuthor(norm);
+
+        // Reset follow UI on author switch
+        setIsFollowing(false);
+        setFollowerCount(norm?.followers ?? 0);
       })
       .catch((err) => {
         console.warn("author fetch failed:", err?.message || err);
         setAuthor(null);
+        setIsFollowing(false);
+        setFollowerCount(0);
       })
       .finally(() => {
         if (alive) setLoading(false);
@@ -75,12 +93,24 @@ const Author = () => {
     }
   };
 
-  // keep your layout; just hydrate values (or show fallbacks while loading)
+  // Front-end only follow toggle
+  const handleToggleFollow = () => {
+    // If we don't have initial data yet, do nothing
+    if (loading) return;
+
+    setFollowerCount((prev) => {
+      // Increase when following, decrease when unfollowing (never < 0)
+      if (!isFollowing) return prev + 1;
+      return Math.max(0, prev - 1);
+    });
+    setIsFollowing((prev) => !prev);
+  };
+
+  // Keep your layout; just hydrate values (or show fallbacks while loading)
   const avatar = author?.avatar || AuthorImageFallback;
   const name = loading ? "Loading…" : author?.name || "Unknown Artist";
   const username = loading ? "" : author?.username || "@unknown";
   const wallet = author?.wallet || "";
-  const followers = author?.followers ?? 0;
 
   return (
     <div id="wrapper">
@@ -98,13 +128,14 @@ const Author = () => {
         <section aria-label="section">
           <div className="container">
             <div className="row">
+              {/* Header */}
               <div className="col-md-12">
                 <div className="d_profile de-flex">
                   <div className="de-flex-col">
                     <div className="profile_avatar">
                       <img src={avatar} alt={name} />
-
                       <i className="fa fa-check"></i>
+
                       <div className="profile_name">
                         <h4>
                           {name}
@@ -123,20 +154,30 @@ const Author = () => {
                       </div>
                     </div>
                   </div>
+
+                  {/* Followers + Follow/Unfollow (front-end only) */}
                   <div className="profile_follow de-flex">
                     <div className="de-flex-col">
                       <div className="profile_follower">
-                        {followers.toLocaleString()} followers
+                        {followerCount.toLocaleString()} followers
                       </div>
-                      <Link to="#" className="btn-main">
-                        Follow
-                      </Link>
+
+                      {/* Using a button so there's no navigation; keep theme class for styling */}
+                      <button
+                        type="button"
+                        className="btn-main"
+                        onClick={handleToggleFollow}
+                        aria-pressed={isFollowing}
+                        disabled={loading}
+                      >
+                        {isFollowing ? "Unfollow" : "Follow"}
+                      </button>
                     </div>
                   </div>
                 </div>
               </div>
 
-              {/* Tabs / items — leaving as-is; we can wire this up to the same :id next */}
+              {/* Tabs / items (unchanged) */}
               <div className="col-md-12">
                 <div className="de_tab tab_simple">
                   <AuthorItems />

--- a/src/pages/Author.jsx
+++ b/src/pages/Author.jsx
@@ -1,10 +1,87 @@
-import React from "react";
+// src/pages/Author.jsx
+// Notes (from me to future me):
+// - Kept original structure/classes so we don’t fight site-wide CSS.
+// - Only change is: read :id from the route, fetch author by that id, and hydrate the header.
+// - Safe fallbacks are in place so the UI doesn’t break if a field is missing.
+
+import React, { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import axios from "axios";
+
 import AuthorBanner from "../images/author_banner.jpg";
 import AuthorItems from "../components/author/AuthorItems";
-import { Link } from "react-router-dom";
-import AuthorImage from "../images/author_thumbnail.jpg";
+import AuthorImageFallback from "../images/author_thumbnail.jpg";
+
+const API =
+  "https://us-central1-nft-cloud-functions.cloudfunctions.net/authors";
+
+// normalize anything the function might return into what we render
+function normalizeAuthor(raw) {
+  return {
+    name: raw?.name || raw?.authorName || "Unknown Artist",
+    username: raw?.tag || raw?.username || "@unknown",
+    wallet: raw?.wallet || raw?.address || "",
+    followers:
+      typeof raw?.followers === "number"
+        ? raw.followers
+        : Number(raw?.followers) || 0,
+    avatar: raw?.authorImage || raw?.avatar || AuthorImageFallback,
+  };
+}
 
 const Author = () => {
+  const { id } = useParams(); // /author/:id
+  const [author, setAuthor] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  // fetch the author when :id changes
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+
+    if (!id) {
+      setAuthor(null);
+      setLoading(false);
+      return;
+    }
+
+    axios
+      .get(`${API}?author=${encodeURIComponent(id)}`, { timeout: 8000 })
+      .then(({ data }) => {
+        if (!alive) return;
+        // API may return an object or array — be defensive
+        const raw = Array.isArray(data) ? data[0] : data;
+        setAuthor(raw ? normalizeAuthor(raw) : null);
+      })
+      .catch((err) => {
+        console.warn("author fetch failed:", err?.message || err);
+        setAuthor(null);
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [id]);
+
+  const handleCopy = () => {
+    if (!author?.wallet) return;
+    try {
+      navigator.clipboard.writeText(author.wallet);
+    } catch {
+      // noop
+    }
+  };
+
+  // keep your layout; just hydrate values (or show fallbacks while loading)
+  const avatar = author?.avatar || AuthorImageFallback;
+  const name = loading ? "Loading…" : author?.name || "Unknown Artist";
+  const username = loading ? "" : author?.username || "@unknown";
+  const wallet = author?.wallet || "";
+  const followers = author?.followers ?? 0;
+
   return (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">
@@ -25,17 +102,21 @@ const Author = () => {
                 <div className="d_profile de-flex">
                   <div className="de-flex-col">
                     <div className="profile_avatar">
-                      <img src={AuthorImage} alt="" />
+                      <img src={avatar} alt={name} />
 
                       <i className="fa fa-check"></i>
                       <div className="profile_name">
                         <h4>
-                          Monica Lucas
-                          <span className="profile_username">@monicaaaa</span>
-                          <span id="wallet" className="profile_wallet">
-                            UDHUHWudhwd78wdt7edb32uidbwyuidhg7wUHIFUHWewiqdj87dy7
-                          </span>
-                          <button id="btn_copy" title="Copy Text">
+                          {name}
+                          {username && (
+                            <span className="profile_username">{username}</span>
+                          )}
+                          {wallet && (
+                            <span id="wallet" className="profile_wallet">
+                              {wallet}
+                            </span>
+                          )}
+                          <button id="btn_copy" title="Copy Text" onClick={handleCopy}>
                             Copy
                           </button>
                         </h4>
@@ -44,7 +125,9 @@ const Author = () => {
                   </div>
                   <div className="profile_follow de-flex">
                     <div className="de-flex-col">
-                      <div className="profile_follower">573 followers</div>
+                      <div className="profile_follower">
+                        {followers.toLocaleString()} followers
+                      </div>
                       <Link to="#" className="btn-main">
                         Follow
                       </Link>
@@ -53,6 +136,7 @@ const Author = () => {
                 </div>
               </div>
 
+              {/* Tabs / items — leaving as-is; we can wire this up to the same :id next */}
               <div className="col-md-12">
                 <div className="de_tab tab_simple">
                   <AuthorItems />


### PR DESCRIPTION
**TASK**
- Fetched an author’s items via axios using the dynamic endpoint .../authors?author=:id.
- Normalized the API payload (handles both object and array shapes) into the exact card model we render.
- Preserved the existing theme/layout and card markup.
- Implemented a skeleton loading state.
- Kept author and item links intact:
- Avatar → /author/:authorId
- Image/title → /item-details/:nftId
- Included a tiny, scoped shimmer for skeletons (no global CSS changes)

**WHY**
- The author page should render the actual items for the author whose :id appears in the URL.
- Skeletons show progress while data loads.
- Keeping the existing markup ensures we don’t fight global CSS.

**HOW**
- Read :id from the route via useParams() and request:
- GET [https://us-central1-nft-cloud-functions.cloudfunctions.net/authors?author=${encodeURIComponent(id)}](https://us-central1-nft-cloud-functions.cloudfunctions.net/authors?author=$%7BencodeURIComponent(id)%7D)
- Loading state:
- loading=true → render 8 skeleton cards (same footprint as real cards)
- On success → swap skeletons for data
- On empty → show “No items yet.”
<img width="1118" height="626" alt="Loading State" src="https://github.com/user-attachments/assets/db1c82e1-4f03-43a1-a0f2-2b494e58b9bc" />
